### PR TITLE
Remove port change on SNMP domain specification

### DIFF
--- a/libexec/check_interface_table_v3t.pl.in
+++ b/libexec/check_interface_table_v3t.pl.in
@@ -6489,8 +6489,6 @@ sub print_usage () {
         <privproto> : Priv protocole (des|aes : default des)
     --domain
         SNMP transport domain. Can be: udp (default), tcp, udp6, tcp6.
-        Specifying a transport domain also change the default port according
-        to that selected transport domain. Use --port to overwrite the port.
     --contextname
         Context name for the snmp requests (snmpv3 only)
     -P, --port=PORT
@@ -7254,17 +7252,8 @@ sub check_options () {
         $ghSNMPOptions{'max-repetitions'} = $commandline{'max-repetitions'};
     }
     if (exists $commandline{domain}) {
-        if ($commandline{domain} =~ /^udp$|^tcp$|^udp6$|^tcp6$/i) {
+        if ($commandline{domain} =~ /^(?:udp|tcp)6?$/i) {
             $ghSNMPOptions{'domain'} = "$commandline{domain}";
-            if ($commandline{domain} eq "udp") {
-                $ghSNMPOptions{'port'} = 161;
-            } elsif ($commandline{domain} eq "tcp") {
-                $ghSNMPOptions{'port'} = 1161;
-            } elsif ($commandline{domain} eq "udp6") {
-                $ghSNMPOptions{'port'} = 10161;
-            } elsif ($commandline{domain} eq "tcp6") {
-                $ghSNMPOptions{'port'} = 1611;
-            }
         } else {
             print "Specified transport domain \"$commandline{domain}\" is not valid. Valid domains are: udp, tcp, udp6, tcp6.\n";
             exit $ERRORS{"UNKNOWN"};


### PR DESCRIPTION
By default every domain uses port 161 - even TCP/UDP.

Specifying another port should be a user decision.