### PR TITLE
Feature/use ifname instead of ifdesc

### DIFF
--- a/libexec/check_interface_table_v3t.pl.in
+++ b/libexec/check_interface_table_v3t.pl.in
@@ -1706,7 +1706,7 @@ sub Get_InterfaceNames {
     # Example of $refhSNMPResultIfDescr
     #    TOADD
     while ( my ($Index,$Desc) = each(%$refhSNMPResultIfDescr) ) {
-        $Index =~ s/^\.*$oid_ifDescr{'oid'}\.//g; # remove all but the index
+        $Index =~ s/^\.*$refhOIDIfDescr->{'oid'}\.//g; # remove all but the index
         logger(2, "Index=$Index Descr=\"$Desc\" (long cache: $gLongCacheTimer)");
         my $MacAddr = (defined $refhSNMPResultIfPhysAddress->{$Index}) ? "$refhSNMPResultIfPhysAddress->{$Index}" : "";
 

--- a/libexec/check_interface_table_v3t.pl.in
+++ b/libexec/check_interface_table_v3t.pl.in
@@ -7075,7 +7075,7 @@ sub check_options () {
         }
     }
     if (exists $commandline{'ifname'}) {
-        if ($ghOptions{nodetype} !~ /^standard$/i) {
+        if ($ghOptions{nodetype} =~ /^standard$/i) {
             $ghOptions{'ifname'} = $commandline{'ifname'};
         } else {
             print "Option \"--ifname\" not supported for the nodetype \"$ghOptions{nodetype}\".\n";

--- a/libexec/check_interface_table_v3t.pl.in
+++ b/libexec/check_interface_table_v3t.pl.in
@@ -57,7 +57,7 @@ use vars qw($TIMEOUT %ERRORS $PROGNAME $REVISION $CONTACT);
 $TIMEOUT = 15;
 %ERRORS = ('OK'=>0,'WARNING'=>1,'CRITICAL'=>2,'UNKNOWN'=>3,'DEPENDENT'=>4);
 $PROGNAME        = $0;
-$REVISION        = '0.05-2b';
+$REVISION        = '0.05-2c';
 $CONTACT         = 'tontonitch-pro@yahoo.fr';
 my %ERRORCODES   = (0=>'OK',1=>'WARNING',2=>'CRITICAL',3=>'UNKNOWN',4=>'DEPENDENT');
 my %COLORS       = ('HighLight' => '#81BEF7');
@@ -1113,7 +1113,11 @@ elsif ($ghOptions{'nodetype'} eq "hpux") {
 }
 # +++++ Standard device +++++
 else {
-    Get_InterfaceNames (\%oid_ifDescr, \%oid_ifPhysAddress); # Gather interface indexes, descriptions, and mac addresses, to generate unique and reformatted interface names.
+    if ($ghOptions{'ifname'}) { 
+        Get_InterfaceNames (\%oid_ifName, \%oid_ifPhysAddress); # Gather interface indexes, descriptions, and mac addresses, to generate unique and reformatted interface names.
+    } else {
+        Get_InterfaceNames (\%oid_ifDescr, \%oid_ifPhysAddress); # Gather interface indexes, descriptions, and mac addresses, to generate unique and reformatted interface names.
+    }
     Get_InterfaceType (\%oid_ifType) if ($ghOptions{'type'} or $ghOptions{'table-split'}); # Gather interface types
     Get_AdminStatus (\%oid_ifAdminStatus); # Gather interface administration status
     Get_OperStatus (\%oid_ifOperStatus); # Gather interface operational status
@@ -6355,7 +6359,7 @@ sub print_usage () {
         [--portperfunit <unit>] [--perfdataformat <format>] [--perfdatathreshold <format>] [--outputshort]
         [--snmp-timeout <timeout>] [--snmp-retries <number of retries>] [--snmp-maxmsgsize <maximum message size>]
         [--(no)configtable] [--(no)unixsnmp] [--debugfile=/path/to/file.debug]
-        [--(no)pkt] [--(no)type]
+        [--(no)pkt] [--(no)type] [--ifname]
 
     * other usages:
       $PROGNAME [--help | -?]
@@ -6591,6 +6595,8 @@ sub print_usage () {
         Add the ip information for each interface in the interface table.
     --(no)alias (optional)
         Add the alias information for each interface in the interface table.
+    --ifname (optional)
+        Use OID ifName instead of ifDesc for nodetype standard.
     --accessmethod (optional)
         Access method for a shortcut to the host in the HTML page.
         Format is : <method>[:<target>]
@@ -6780,6 +6786,7 @@ sub check_options () {
         'tips!',                                # Enable or not the tips
         'default-table-sorting=s',              # Default table sorting, can be index (default) or name
         'table-split!',                         # Generate multiple interface tables, one per interface type (~ifType)
+        'ifname',                               # Use ifName instead of ifDesc in nodetype standard
         #------- deprecated options ---------#
         'cisco',                                # replaced by --nodetype=cisco
         );
@@ -6863,6 +6870,7 @@ sub check_options () {
         'tips'                      => 1,
         'default-table-sorting'     => "index",              # Default table sorting, can be index (default) or name
         'table-split'               => 0,
+        'ifname'                    => 0,
     );
     # Default values: snmp options
     %ghSNMPOptions = (
@@ -7066,6 +7074,15 @@ sub check_options () {
             exit $ERRORS{"UNKNOWN"};
         }
     }
+    if (exists $commandline{'ifname'}) {
+        if ($ghOptions{nodetype} !~ /^standard$/i) {
+            $ghOptions{'ifname'} = $commandline{'ifname'};
+        } else {
+            print "Option \"--ifname\" not supported for the nodetype \"$ghOptions{nodetype}\".\n";
+            exit $ERRORS{"UNKNOWN"};
+        }
+    }
+
     if (exists $commandline{pkt}) {
         $ghOptions{'pkt'} = $commandline{pkt};
     }


### PR DESCRIPTION
Hi Yannick,

since Debian 8 I recognized that using nodetype standard the OID _ifDesc_ isn't usefull as interface name anymore.

I get names like this:
e.g. "Realtek Semiconductor Co., Ltd. RTL8111/8168/8411 PCI Express Gigabit Ethernet Controller" for a real server, or "VMware VMXNET3 Ethernet Controller" for a VMWare virtual maschine.

I added the option "`--ifname`" to interfacetable_v3t that uses the OID ifName (_%oid_ifName_) instead of ifDesc (_%oid_ifDesc_) for nodetype standard.

Regards,
Frank
